### PR TITLE
bundle update responders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,8 @@ GEM
       ffi (~> 1.0)
     regexp_parser (1.6.0)
     responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)


### PR DESCRIPTION
# WHAT
bundle update respondersを行った
# WHY
本番環境にデプロイする際に下記エラーが出たため
Either installing with `--full-index` or running `bundle update responders`