### PR TITLE
複数画像投稿機能の修正

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', () => {
+$(function() {
   // 画像用のinputを生成する関数
   const buildFileField = (num) => {
     const html = `<div data-index="${num}" class="js-file_group">


### PR DESCRIPTION
# What
$(document).on('turbolinks:load', () =>を$(function()に変えた。

# Why
turbolinksが使えなくなったから。