### PR TITLE
遷移先修正

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,7 +5,7 @@ class CardsController < ApplicationController
 
   def new
     card = Card.where(user_id: current_user.id)
-    redirect_to action: "show" if card.exists?
+    redirect_to action: "delete" if card.exists?
   end
 
   def pay


### PR DESCRIPTION
# what
クレジットカード登録後、遷移先をカード削除画面に変更。

# why
ユーザーの使いやすさ向上のため。