### PR TITLE
ユーザー登録&住所登録　エラーメッセージの日本語化

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -25,6 +25,17 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+        nickname: ニックネーム
+        family_name: 苗字
+        first_name: 名前
+        family_name_kana: 苗字のふりがな
+        first_name_kana: 名前のふりがな
+        birthday: 生年月日
+      adress: 
+        post_number: 郵便番号
+        prefecture_id: 都道府県
+        municipality: 市区町村
+        town: 番地
     models:
       user: ユーザ
   devise:


### PR DESCRIPTION
# What
devise.ja.ymlに日本語を記述しました。
エラーメッセージが日本語で出ることを確認済みです。
