### PR TITLE
 商品詳細ページの修正

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  def previous
+    Item.where("id < ?", self.id).order("id DESC").first
+  end
+  def next
+    Item.where("id > ?", self.id).order("id ASC").first
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -109,8 +109,8 @@
         コメントする
   %ul.itemShow__Go
     %li
-      -if (@item.id - 1 > 0)
-        = link_to item_path(@item.id-1) do
+      -if (@item.previous)
+        = link_to item_path(@item.previous) do
           =icon("fas","angle-left")
           %span 前の商品
       -else

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -118,8 +118,8 @@
           =icon("fas","angle-left")
           %span 前の商品
     %li
-      -if (@item.id+1 <= @items.length)
-        = link_to item_path(@item.id+1) do
+      -if (@item.next)
+        = link_to item_path(@item.next) do
           %span 後ろの商品
           =icon("fas","angle-right")
       -else


### PR DESCRIPTION
# what
前後の商品ページの取得をできるようにした。

# Why
今までのやり方では、本番環境で不備が出るため。